### PR TITLE
switch from STATIC to SHARED emod-utils library

### DIFF
--- a/include/emodlib/malaria/CMakeLists.txt
+++ b/include/emodlib/malaria/CMakeLists.txt
@@ -12,6 +12,6 @@ add_library(${EMODLIB_MALARIA_TARGET} SHARED
 # include top-level directory to allow full include paths
 target_include_directories(${EMODLIB_MALARIA_TARGET} PUBLIC ${CMAKE_SOURCE_DIR}/include)
 
-target_link_libraries(${EMODLIB_MALARIA_TARGET} PRIVATE pybind11::embed emodlib-utils)
+target_link_libraries(${EMODLIB_MALARIA_TARGET} PUBLIC pybind11::embed emodlib-utils)
 
 target_compile_features(${EMODLIB_MALARIA_TARGET} PUBLIC cxx_std_14)

--- a/include/emodlib/utils/CMakeLists.txt
+++ b/include/emodlib/utils/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(EMODLIB_UTILS_TARGET emodlib-utils)
 
-add_library(${EMODLIB_UTILS_TARGET} STATIC suids.cpp RANDOM.cpp)
+add_library(${EMODLIB_UTILS_TARGET} SHARED suids.cpp RANDOM.cpp)
 
 target_compile_features(${EMODLIB_UTILS_TARGET} PUBLIC cxx_std_14)


### PR DESCRIPTION
Ubuntu/gcc seemed to have issues trying to link the malaria library against the static utils library?