### PR TITLE
Adding mature gametocyte waning + naive-challenge example plot

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,0 +1,29 @@
+Falciparum_MSP_Variants: 32
+Falciparum_Nonspecific_Types: 76
+Falciparum_PfEMP1_Variants: 1070
+Run_Number: 12345
+infection_params:
+  Antibody_IRBC_Kill_Rate: 1.596
+  Antigen_Switch_Rate: 7.645570124964182e-10
+  Base_Gametocyte_Fraction_Male: 0.2
+  Base_Gametocyte_Production_Rate: 0.06150582
+  Base_Incubation_Period: 7
+  Gametocyte_Stage_Survival_Rate: 0.588569307
+  MSP1_Merozoite_Kill_Fraction: 0.511735322
+  Merozoites_Per_Hepatocyte: 15000
+  Merozoites_Per_Schizont: 16
+  Nonspecific_Antigenicity_Factor: 0.415111634
+  Number_Of_Asexual_Cycles_Without_Gametocytes: 1
+  RBC_Destruction_Multiplier: 3.29
+susceptibility_params:
+  Antibody_CSP_Decay_Days: 90
+  Antibody_Capacity_Growth_Rate: 0.09
+  Antibody_Memory_Level: 0.34
+  Antibody_Stimulation_C50: 30
+  Erythropoiesis_Anemia_Effect: 3.5
+  Fever_IRBC_Kill_Rate: 1.4
+  Maternal_Antibody_Decay_Rate: 0.01
+  Max_MSP1_Antibody_Growthrate: 0.045
+  Min_Adapted_Response: 0.05
+  Nonspecific_Antibody_Growth_Rate_Factor: 0.5
+  Pyrogenic_Threshold: 15000.0

--- a/examples/naive_infection.py
+++ b/examples/naive_infection.py
@@ -1,0 +1,51 @@
+import yaml
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+
+from emodlib.malaria import *
+
+
+def configure_from_file(config_path):
+
+    with open(config_path) as cfg:
+        params = yaml.load(cfg, Loader=yaml.FullLoader)
+
+    print(yaml.dump(params))
+
+    IntrahostComponent.configure(params)
+
+
+def run_challenge(duration):
+
+    asexuals = np.zeros(duration)
+    gametocytes = np.zeros(duration)
+
+    ic = IntrahostComponent.create()
+    ic.challenge()
+
+    for t in range(duration):
+        ic.update(dt=1)
+        asexuals[t] = ic.parasite_density
+        gametocytes[t] = ic.gametocyte_density
+
+    return pd.DataFrame({'days': range(duration),
+                         'parasite_density': asexuals,
+                         'gametocyte_density': gametocytes}).set_index('days')
+
+
+if __name__ == '__main__':
+
+    configure_from_file('config.yaml')
+
+    df = run_challenge(duration=300)
+    print(df.head(10))
+
+    fig, ax = plt.subplots(1, 1, figsize=(8, 3))
+    df.plot(ax=ax, color=dict(parasite_density='navy', gametocyte_density='darkgreen'))
+    ax.set(yscale='log')
+    fig.set_tight_layout(True)
+
+    plt.show()
+    

--- a/include/emodlib/malaria/InfectionMalaria.h
+++ b/include/emodlib/malaria/InfectionMalaria.h
@@ -104,6 +104,7 @@ namespace emodlib
             void malariaImmunityIRBCKill(float dt);
             void malariaImmunityGametocyteKill(float dt);
             void malariaCheckInfectionStatus(float dt);  // TODO: emodlib#3 (InfectionStateChange::Cleared)
+            void apply_MatureGametocyteKillProbability(float pkill);
 
         };
 


### PR DESCRIPTION
Addressing issue #5.

Note, however, that this will not be the exact same behavior as in the monolithic codebase if model state is queried at the end of the update step, where the mature gametocyte waning code has been added adjacent to the early-stage drug-killing effects.  That's because the waning has been calculated after infectiousness is calculated at the beginning of the following time step in the original code [in IndividualMalaria.cpp](https://github.com/InstituteforDiseaseModeling/DtkTrunk/blob/master/Eradication/IndividualMalaria.cpp#L351) as part of [updateInfectivity](https://github.com/InstituteforDiseaseModeling/DtkTrunk/blob/master/Eradication/Node.cpp#L883) before the individual [Update](https://github.com/InstituteforDiseaseModeling/DtkTrunk/blob/master/Eradication/Node.cpp#L897) loop with [sub-timestep updates](https://github.com/InstituteforDiseaseModeling/DtkTrunk/blob/master/Eradication/Individual.cpp#L640) to infections + immunity.